### PR TITLE
add endpoint configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The `initialize` method takes two arguments:
     -   `disableUserIdStorage` - A boolean indicating whether or not to store the provided user id in storage. Defaults to `false`
     -   `blockCommonBots` - A boolean indicating whether or not to block common bots from being tracked. Defaults to `true`
     -   `anonymousIdOverride` - A string value to be used as the anonymous id of the device the user is on.
+    -   `endpoint` - A string value used as the base path for sending events to, useful in case you need to proxy events through a server. Defaults to `https://integration-api.userflux.co`.
 
 ## 3. Tracking events
 

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ class UserFlux {
 	static ufConsecutiveFailures = 0
 	static ufMaxConsecutiveFailures = 3
 	static ufRetryDelay = 1000 // 1 second delay between retries
+	static ufEndpoint = "https://integration-api.userflux.co"
 
 	static initialize(apiKey, options) {
 		try {
@@ -26,6 +27,10 @@ class UserFlux {
 			}
 
 			UserFlux.ufApiKey = apiKey
+
+			if ("endpoint" in options && typeof options["endpoint"] === "string") {
+				UserFlux.ufEndpoint = options["endpoint"]
+			}
 
 			if ("allowCookies" in options && options["allowCookies"] == true) {
 				UserFlux.ufAllowCookies = true
@@ -700,7 +705,7 @@ class UserFlux {
 		}
 
 		try {
-			await fetch(`https://integration-api.userflux.co/${endpoint}?locationEnrichment=${locationEnrich}`, {
+			await fetch(`${UserFlux.ufEndpoint}/${endpoint}?locationEnrichment=${locationEnrich}`, {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@userflux/browser-js-lite",
-	"version": "1.0.6",
+	"version": "1.0.7",
 	"description": "UserFlux's Brower SDK (Lite) - send your frontend analytics data to the UserFlux platform",
 	"main": "index.js",
 	"types": "index.d.ts",


### PR DESCRIPTION
add the ability to configure the base endpoint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a configurable base API endpoint and switches network calls to use it.
> 
> - Adds `endpoint` option to `initialize` to set `UserFlux.ufEndpoint` (defaults to `https://integration-api.userflux.co`)
> - Updates `sendRequest` to use `${UserFlux.ufEndpoint}/...` instead of a hardcoded URL
> - Documents the new option in `README.md` and bumps package version to `1.0.7`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5cb82c20748103c4f2e35bc02b20814bafd1568e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->